### PR TITLE
[Fixed] ' rails g' コマンドの際にいらないファイルが生成されないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,8 @@ module Achieve
         routing_specs: false,
         controller_specs: true,
         request_specs: false
+      g.assets     false
+      g.helper     false
       g.fixture_replacement :factory_girl, dir: "spec/factories"
     end
   end


### PR DESCRIPTION
 #1 

Config/Application.rbに以下のコードを追加
　　g.assets     false
       g.helper     false